### PR TITLE
Changed 'statdir' path

### DIFF
--- a/config-templates/module_statistics.php
+++ b/config-templates/module_statistics.php
@@ -22,7 +22,7 @@ $config = [
 
     'default' => 'sso',
 
-    'statdir' => '/tmp/stats/',
+    'statdir' => '/var/simplesamlphp/stats/',
     'inputfile' => '/var/log/simplesamlphp.stat',
     'offset' => 60 * 60 * 2 + 60 * 60 * 24 * 3, // Two hours offset to match epoch and norwegian winter time.
 


### PR DESCRIPTION
I have changed the default 'statdir' path because if it is used, SimpleSAMLphp v2.0.0 IdP says that `/tmp/stats` does not exist also if exists and has the right permissions.